### PR TITLE
Fixed small bug in error reporting with config parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ Debug/*
 LuaBackend/Debug/*
 LuaBackend/scripts/*
 *.user
+LuaBackendEXE/x64/*
+LuaBackendLIB/x64/*
+LuaBackendDLL/x64/*
+x64/*

--- a/LuaBackendEXE/main.cpp
+++ b/LuaBackendEXE/main.cpp
@@ -54,7 +54,8 @@ int main()
 	try { config.read(); }
 
 	catch (exception& e) {
-		ConsoleLib::MessageOutput(e.what() + '\n', 3);
+		string message = e.what();
+		ConsoleLib::MessageOutput(message + '\n', 3);
 		EnterWait();
 		return -5;
 	}


### PR DESCRIPTION
This fixes a small visual bug where LuaBackend will not print the first 9 or so characters of the error message whenever there is a config parsing error. I have no idea if there is a better way to do this or not, but it works. I also had to modify the gitignore file to ignore some compile directories created by my setup.