### PR TITLE
Remove hard dependency on discord-rpc.dll

### DIFF
--- a/LuaBackendDLL/LuaBackendDLL.vcxproj
+++ b/LuaBackendDLL/LuaBackendDLL.vcxproj
@@ -74,7 +74,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>../LuaBackendLIB/libraries/lua/lua54.lib;../LuaBackendLIB/libraries/discord/discord-rpc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>../LuaBackendLIB/libraries/lua/lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -93,7 +93,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>../LuaBackendLIB/libraries/lua/lua54.lib;../LuaBackendLIB/libraries/discord/discord-rpc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>../LuaBackendLIB/libraries/lua/lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/LuaBackendEXE/LuaBackendEXE.vcxproj
+++ b/LuaBackendEXE/LuaBackendEXE.vcxproj
@@ -75,7 +75,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>../LuaBackendLIB/libraries/lua/lua54.lib;../LuaBackendLIB/libraries/discord/discord-rpc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>../LuaBackendLIB/libraries/lua/lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -94,7 +94,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>../LuaBackendLIB/libraries/lua/lua54.lib;../LuaBackendLIB/libraries/discord/discord-rpc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>../LuaBackendLIB/libraries/lua/lua54.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
Simply just load the DLL manually and getting the functions we need. If the DLL isn't found we just replace the call with a stub function.